### PR TITLE
Fixed the recurring warning about deprecated md5 in the visDQMUpload script

### DIFF
--- a/bin/visDQMUpload
+++ b/bin/visDQMUpload
@@ -1,6 +1,16 @@
 #!/usr/bin/env python
 
-import sys, os, os.path, re, string, httplib, mimetypes, urllib, urllib2, httplib, gzip, md5
+import sys
+import os
+import re
+import string
+import httplib
+import mimetypes
+import urllib
+import urllib2
+import httplib
+import gzip
+import hashlib
 from cStringIO import StringIO
 from stat import *
 
@@ -113,7 +123,7 @@ try:
   (headers, data) = \
     upload(sys.argv[1],
            { 'size': os.stat(sys.argv[2])[ST_SIZE],
-             'checksum': "md5:%s" % md5.new(file(sys.argv[2]).read()).hexdigest() },
+             'checksum': "md5:%s" % hashlib.md5(file(sys.argv[2]).read()).hexdigest() },
            { 'file': sys.argv[2] })
   print 'Status code: ', headers.get("Dqm-Status-Code", "None")
   print 'Message:     ', headers.get("Dqm-Status-Message", "None")


### PR DESCRIPTION
This is just completely unrelated to all the rest.
Can be integrated at any point.
Tested by uploading
- to local test machine (http)
- to cmsweb dev vocms133 (https)
  Works just fine. The change is super small: just using hashlib instead of md5 to calculate the md5 checksum.
