### PR TITLE
Fixed bug in server-side regex to check uploads

### DIFF
--- a/src/python/DQM/GUI.py
+++ b/src/python/DQM/GUI.py
@@ -174,7 +174,7 @@ class DQMFileAccess(DQMUpload):
     self._check("checksum", checksum,      r"^(md5:[A-Za-z0-9]+|crc32:\d+)$")
     self._check("filename", file.filename, r"^[-A-Za-z0-9_]+\.root$")
 
-    m = re.match(r"^(DQM)_V\d+(_[A-Za-z]+)?_R(\d+)(__.*)?\.root", str(file.filename))
+    m = re.match(r"^(DQM)_V\d+(_[A-Za-z0-9]+)?_R(\d+)(__.*)?\.root", str(file.filename))
     if not m:
       self._error(self.STATUS_ERROR_PARAMETER,
                   "File name does not match the expected convention")


### PR DESCRIPTION
The problem is that a file name like:
    DQM_V0001_DT_R000192969.root
can be uploaded.
But a filename like:
    DQM_V0001_L1T_R000233114.root
can not be uploaded.

In the online world this is not a big problem, since files are dropped
in the upload directory right away, bypassing the webserver.
But if you ever would want to manually upload the set of root files
generated in the online world, this would simply be impossible for all
the ones that have a number in the subsystem name.

```
The first regex on the receiving side of the server is:
^(DQM)_V\d+(_[A-Za-z]+)?_R(\d+)(__.*)?\.root
The first regex in the receive daemon is:
^[-A-Za-z0-9_/]+\.root$
Followed by the regex to classify it as Online:
^(?:.*/)?DQM_V(\d+)(_[A-Za-z0-9]+)?_R(\d+)\.root$
```

So the problem was that on the server no numbers were allowed in the
subsystem name, while the receive daemon has no problems with it.
This is what was fixed.
