### PR TITLE
Fixing very old include in example render plugin

### DIFF
--- a/test/cpp/TestDQMRenderPlugin.cc
+++ b/test/cpp/TestDQMRenderPlugin.cc
@@ -1,4 +1,4 @@
-#include "VisMonitoring/DQMServer/interface/DQMRenderPlugin.h"
+#include "DQM/DQMRenderPlugin.h"
 #include "TCanvas.h"
 #include "TText.h"
 #include "TColor.h"


### PR DESCRIPTION
Reason for this it that the render plugin Twiki refers to a file which
has long ago been moved and seems not to have been maintained.
