### PR TITLE
Bug in the code handling when file not (yet) taped

### DIFF
--- a/bin/visDQMZipCastorVerifier
+++ b/bin/visDQMZipCastorVerifier
@@ -191,7 +191,7 @@ try:
       (rc, so, se) = runme("nsls -T %s", cname)
       if not rc == 0:
         assert False, "WARNING: %s: nsls -T failed with following error:[%d,'%s']" % \
-              (cname,rc,so,se)
+              (cname,rc,se)
 
       if so == "":
         (rc, so, se) = runme("stager_qry -M %s", cname)


### PR DESCRIPTION
Each time the agent tried to check if a file was on tape and the result
of the query was that the file was NOT yet on tape, a warning message
was supposed to be sent. But instead of that the program simply crashed
because of a bug in the code that tried to format the warning-message.
As a result of the crash the entire process would get stuck in an eternal
loop, until the file was actually written to tape.
This bug was very old, but never noticed because actually the tape
storage works really well.
