### PR TITLE
Fix vIsDQMImportDaemon for hostnames without any periods

### DIFF
--- a/bin/visDQMImportDaemon
+++ b/bin/visDQMImportDaemon
@@ -60,7 +60,7 @@ MODE = 'Offline'
 
 # Detect mode of operation
 hostName = getfqdn()
-if hostName.split(".")[1] == "cms":
+if hostName.endswith(".cms"):
   MODE = 'Online'
 
 # --------------------------------------------------------------------


### PR DESCRIPTION
e.g. "dqmgui-ci-worker-8e855cad50f1" now works
and "machinename.cms" still works