### PR TITLE
JSROOT plots updates with new data without canvas reseting on auto refresh

### DIFF
--- a/src/javascript/DQM/Canvas.js
+++ b/src/javascript/DQM/Canvas.js
@@ -13,6 +13,7 @@ var _SIZES            =
 var _SIZESARRAY       = _map(_SIZES, function(x) { return [x.title, x.label]; });
 var _SIZEMAP          = {};
 _map(_SIZES, function(x) { _SIZEMAP[x.label] = x; });
+JSROOT.gStyle.MathJax = 1;
 // Resize an image to fit the canvas.
 function setsize(canvas, img, size, row, rows, col, cols)
 {

--- a/src/javascript/DQM/Canvas.js
+++ b/src/javascript/DQM/Canvas.js
@@ -1270,14 +1270,17 @@ GUI.Plugin.DQMCanvas = new function()
     });
 
     Promise.all(promises).then(objects => {
+      let stack = JSROOT.Create("THStack");
       objects.forEach((ob, index) => {
         ob.fLineColor = colors[index]
         if (index > 0 ){          
-          ob.fName = 'Ref ' + index;  
-          JSROOT.draw("drawing", ob, 'hist');
+          ob.fName = 'Ref ' + index;
+          ob.fOption = 'hist'
+          stack.fHists.Add(ob);
         }else
-        JSROOT.draw("drawing", ob);
+        stack.fHists.Add(ob);
       })
+      JSROOT.redraw("drawing", stack, "nostack");
     })
   }
 
@@ -1288,7 +1291,7 @@ GUI.Plugin.DQMCanvas = new function()
       _zoomWin.update('<div id="drawing" style="width:100%; height:100%;"></div> ');
     _oldfocusURL = _focusURL.replace(/;v=\d+/, '')
     let jsRootURL = _jsonURL.replace('formatted', 'jsroot').replace('jsonfairy', 'jsrootfairy')
-    if (_focusURL.includes('overlay?') && performUpdate)
+    if (_focusURL.includes('overlay?'))
       _self.updateJsRootOverlays()
     else if(!_focusURL.includes('overlay?'))
       JSROOT.NewHttpRequest(jsRootURL, 'object', obj => {

--- a/src/javascript/DQM/Canvas.js
+++ b/src/javascript/DQM/Canvas.js
@@ -1278,8 +1278,12 @@ GUI.Plugin.DQMCanvas = new function()
           ob.fName = 'Ref ' + index;
           ob.fOption = 'hist'
           stack.fHists.Add(ob);
-        }else
-        stack.fHists.Add(ob);
+        }
+        else
+        {
+          stack.fHists.Add(ob);
+          stack.fTitle = ob.fTitle;
+        }
       })
       JSROOT.redraw("drawing", stack, "nostack");
     })

--- a/src/javascript/DQM/Canvas.js
+++ b/src/javascript/DQM/Canvas.js
@@ -478,6 +478,7 @@ GUI.Plugin.DQMCanvas = new function()
 
   var _jsRootButton     = null;
   var _jsRootMode       = null;
+  var _oldfocusURL      = null;
 
   this.switchJsonMode = function() {
         _jsonMode = _jsonDataButton.pressed;
@@ -1282,12 +1283,14 @@ GUI.Plugin.DQMCanvas = new function()
 
   this.updateJsRoot = function()
   {
-    if( !document.getElementById("drawing") || (_focus != _zoomWin.title) )
+    let performUpdate = _oldfocusURL != _focusURL.replace(/;v=\d+/, '')
+    if( !document.getElementById("drawing") || performUpdate )
       _zoomWin.update('<div id="drawing" style="width:100%; height:100%;"></div> ');
+    _oldfocusURL = _focusURL.replace(/;v=\d+/, '')
     let jsRootURL = _jsonURL.replace('formatted', 'jsroot').replace('jsonfairy', 'jsrootfairy')
-    if (_focusURL.includes('overlay?'))
+    if (_focusURL.includes('overlay?') && performUpdate)
       _self.updateJsRootOverlays()
-    else
+    else if(!_focusURL.includes('overlay?'))
       JSROOT.NewHttpRequest(jsRootURL, 'object', obj => {
          obj.fLineColor = 1;
          JSROOT.redraw("drawing", obj);

--- a/src/javascript/DQM/Canvas.js
+++ b/src/javascript/DQM/Canvas.js
@@ -478,8 +478,6 @@ GUI.Plugin.DQMCanvas = new function()
 
   var _jsRootButton     = null;
   var _jsRootMode       = null;
-  var _jsRootUpdate     = null;
-  var _jsRootUserAction = null;
 
   this.switchJsonMode = function() {
         _jsonMode = _jsonDataButton.pressed;
@@ -673,8 +671,6 @@ GUI.Plugin.DQMCanvas = new function()
 
     _focus = hit.title || null;
 
-    if(e.type)
-      _jsRootUserAction = true;
     /* Update the content of the zoomWindow: this is mandatory to be always
        in sync with respect to whatever changes the end user made using
        the custom panel. This piece of code is called regardless of how
@@ -1286,12 +1282,8 @@ GUI.Plugin.DQMCanvas = new function()
 
   this.updateJsRoot = function()
   {
-    let focusRoot = _focusURL.replace(/;w=\d+/, '').replace(/;h=\d+/, '').replace(/;v=\d+/, '')
-    if(!_jsRootUserAction && _jsRootUpdate == focusRoot && document.getElementById("drawing") )
-      return;
-    _jsRootUpdate = focusRoot
-    _jsRootUserAction = false
-    _zoomWin.update('<div id="drawing" style="width:100%; height:100%;"></div> ');
+    if( !document.getElementById("drawing") || (_focus != _zoomWin.title) )
+      _zoomWin.update('<div id="drawing" style="width:100%; height:100%;"></div> ');
     let jsRootURL = _jsonURL.replace('formatted', 'jsroot').replace('jsonfairy', 'jsrootfairy')
     if (_focusURL.includes('overlay?'))
       _self.updateJsRootOverlays()


### PR DESCRIPTION
Canvas reset on auto update was caused by me unnecessary updating html inside ZoomWin every time a histogram is drawn. I'm doing a check before updating html now. This solves auto refresh bug and on new information histogram is redrawn keeping the users settings intact. 