### PR TITLE
Made the confirmation of file upload more verbose

### DIFF
--- a/src/python/DQM/GUI.py
+++ b/src/python/DQM/GUI.py
@@ -257,7 +257,16 @@ class DQMFileAccess(DQMUpload):
     # Indicate success.
     self._status(self.STATUS_OK, "File saved", "Wrote %d bytes" % nsaved)
     _loginfo("saved file %s size %d checksum %s" % (fname, size, checksum))
-    return "Thanks.\n"
+    message = ("Thanks.\n"
+               "The server received your file. However this does not mean "
+               "that the file was indexed successfully.\n"
+               "A different server process will now check the filename to "
+               "determine in which folder to archive it.\n"
+               "After that, another process will attempt to index it. This "
+               "might take some minutes.\n"
+               "In case of doubt, please check the server logs of the receive-"
+               "daemon and import-daemon.")
+    return message
 
   # ------------------------------------------------------------------
   # Retrieve files from the server.  Pretends to be somewhat like the


### PR DESCRIPTION
Changed the "Thanks" that you receive when uploading a file to the DQM GUI server by a more verbose message stating:
"Thanks.
The server received your file. However this does not mean that the file was indexed successfully.
A different server process will now check the filename to determine in which folder to archive it.
After that, another process will attempt to index it. This might take some minutes.
In case of doubt, please check the server logs of the receive and import daemons."

Tested all the way by doing actual upload of file.