### PR TITLE
Add timeout to tinyurl request

### DIFF
--- a/src/python/Core/GUI.py
+++ b/src/python/Core/GUI.py
@@ -749,7 +749,7 @@ class Server:
     shortUrl = longUrl
 
     try:
-      connection = httplib.HTTPSConnection('tinyurl.com')
+      connection = httplib.HTTPSConnection('tinyurl.com', timeout=3)
       connection.request('GET', '/api-create.php?url=%s' % longUrl)
       response = connection.getresponse()
 


### PR DESCRIPTION
Tinyurl service is not accessible in P5 network and the default timeout time is very long, therefore the link-me feature doesn't terminate in the online GUI. This reduces the timeout time so at least full (not shortened) version of the URL appears when link-me is clicked.