### PR TITLE
Complete the ref label fix

### DIFF
--- a/src/python/DQM/GUI.py
+++ b/src/python/DQM/GUI.py
@@ -942,7 +942,7 @@ class DQMWorkspace:
           param['type']    = "other"
           param['run']     = m.group(1)
           param['dataset'] = m.group(2)
-          param['label']   = m.group(4)
+          param['label']   = m.group(4) or ''
           param['ktest']   = m.group(5)
 	else:
           raise HTTPError(500, "Incorrect referenceobj parameter")


### PR DESCRIPTION
The group is none if it was not matched at all, which is not handled well downstream.

Tested using a link from the development GUI with the second `:` (`%3A` in tinyurl links) removed.