### PR TITLE
Remove import of `GoogleAPI.api_key`

### DIFF
--- a/src/python/Core/GUI.py
+++ b/src/python/Core/GUI.py
@@ -23,7 +23,6 @@ from jsmin import jsmin
 import cPickle as pickle
 import sys, os, os.path, re, tempfile, time, inspect, logging, traceback, hashlib
 import json, cjson, httplib, base64
-from GoogleAPI import api_key
 
 _SESSION_REDIRECT = ("<html><head><script>location.replace('%s')</script></head>"
                      + "<body><noscript>Please enable JavaScript to use this"


### PR DESCRIPTION
After #46 this is no longer needed.

Reported by @vkuznet over at Gitlab:
https://gitlab.cern.ch/cms-http-group/doc/issues/180#note_2820456

Untested, so far.