### PR TITLE
DQMToJSON: Add an argument to search by run.

### DIFF
--- a/src/cpp/DQM/serverext.cc
+++ b/src/cpp/DQM/serverext.cc
@@ -2341,6 +2341,22 @@ public:
 	  }
 	}
 
+	// Match run numbers against run regexp if one was given.
+	if (options.count("run"))
+	{
+	  std::string rxerr;
+	  makerx(options["run"], rx, rxerr, Regexp::IgnoreCase);
+	  if (rx)
+	  {
+	    VisDQMSamples final;
+	    final.reserve(samples.size());
+	    for (size_t i = 0, e = samples.size(); i != e; ++i)
+	      if (rx->search(std::to_string(samples[i].runnr)) >= 0)
+		final.push_back(samples[i]);
+	    std::swap(final, samples);
+	  }
+	}
+
 	for (size_t i = 0, e = samples.size(); i != e; ++i)
 	  stamp = std::max(stamp, samples[i].time * 1e-9);
 


### PR DESCRIPTION
The /data/json/samples endpoint only allows matching by dataset name so
far, and there was no other API way to search by run. This commit adds a
second regular expression argument `run` to search run numbers.

The performance impact of using a regular expression match vs. pure
integer operations needs to be evaluated on a larger volume of data;
however since the rx query on the dataset names performs quite well I
don't expect any problems.

Sample query:
http://.../dqm/online-dev/data/json/samples?run=^32177