### PR TITLE
Added visDQMSoundAlarmManager for enabling/disabling DQM P5 sound alarms

### DIFF
--- a/bin/visDQMSoundAlarmDaemon
+++ b/bin/visDQMSoundAlarmDaemon
@@ -11,7 +11,7 @@ from datetime import datetime
 from urllib import quote
 from fcntl import lockf, LOCK_EX, LOCK_UN
 from socket import socket, AF_INET, SOCK_STREAM, gethostname
-from subprocess import Popen,PIPE
+from subprocess import Popen, PIPE
 
 # IMPORTANT: If you want to play a test sound, just start the program with
 # all the usual parameters, but add "test" as last parameter.
@@ -39,6 +39,12 @@ from subprocess import Popen,PIPE
 # system, the global clock gets reset every time we pass from 0 alarms
 # to at least 1 alarm.
 
+# There is an extension to this tool called visDQMSoundAlarmManager.
+# It's a small web app which displays all plots located in ERROR_FOLDER
+# and provides an abillity to disable alarms for chosen plots. 
+# This tool queries the API of the visDQMSoundAlarmManager for the list 
+# of disabled plots befre sending the alarms.
+
 sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
 
 # --------------------------------------------------------------------
@@ -53,10 +59,16 @@ if len(sys.argv) >= 7:
                                 # accepted, separated by ','
 else:
   EMAIL_ADDRESSES = ''
-# To enable the special "test-mode" add a 7th argument "test"
-# Otherwise the daemon does its normal stuff (which is good)
+
+# URL to get a list of disabled alarms
+ALARM_MANAGER_URL = 'http://localhost:8031/disabled'
 if len(sys.argv) >= 8:
-  IS_TEST = (sys.argv[7] == "test")
+  ALARM_MANAGER_URL = sys.argv[7]
+
+# To enable the special "test-mode" add a 8th argument "test"
+# Otherwise the daemon does its normal stuff (which is good)
+if len(sys.argv) >= 9:
+  IS_TEST = (sys.argv[8] == "test")
 else:
   IS_TEST = False
 
@@ -71,8 +83,6 @@ MSGBODY = ('<CommandSequence><alarm sender="DQM" sound="DQM_1.wav" talk="%s">'
            '%s Check plots in the DQM Error folder.</alarm></CommandSequence>')
 
 WAITTIME = 30
-
-ALARM_MANAGER_URL = 'http://localhost:8071/disabled'
 
 # --------------------------------------------------------------------
 def logme(msg, *args):
@@ -137,8 +147,6 @@ if not sr:
   sys.exit(1)
 
 BASEURL = "%s/%s/%s/" % (BASEURL, DATA_LOCATION, ERROR_FOLDER)
-# TODO: Remove this!!!!
-BASEURL = 'http://localhost:8030/data.json'
 
 # This method is just to test the sound infrastructure.
 # It will try to play a test message, send a test email and then exit.
@@ -203,7 +211,7 @@ def run_daemon():
       knownNewAlarms = set()
       for histo in state["contents"]:
         if histo.has_key('obj'):
-          name = histo['obj']
+          name = '%s/%s' % (histo['dir'], histo['obj'])
         else:
           continue
        
@@ -214,13 +222,12 @@ def run_daemon():
           result = urllib2.build_opener(urllib2.ProxyHandler({})).open(datareq)
           disabledAlarms = json.loads(result.read())
         except:
-          # If we're unable to get disabled alarms, assume that they are enabled
+          # If we're unable to get disabled alarms, assume that all of them are enabled
           pass
 
-        histoFullPath = '%s/%s' % (histo['dir'], histo['obj'])
         if histo['properties']['report']['alarm'] == 1:
-          if histoFullPath in disabledAlarms:
-            logme("Histo caused an alarm but it was disabled in the alarm manager: %s" % histoFullPath)
+          if name in disabledAlarms:
+            logme("Histo caused an alarm but it was disabled in the alarm manager: %s" % name)
           else:
             knownNewAlarms.add(name)
             logme("Info from the DQM GUI: %s" % str(histo))

--- a/bin/visDQMSoundAlarmDaemon
+++ b/bin/visDQMSoundAlarmDaemon
@@ -5,7 +5,7 @@ import re
 import os
 import time
 import sys
-import cjson
+import json
 from traceback import print_exc
 from datetime import datetime
 from urllib import quote
@@ -72,6 +72,8 @@ MSGBODY = ('<CommandSequence><alarm sender="DQM" sound="DQM_1.wav" talk="%s">'
 
 WAITTIME = 30
 
+ALARM_MANAGER_URL = 'http://localhost:8071/disabled'
+
 # --------------------------------------------------------------------
 def logme(msg, *args):
   procid = "[%s/%d]" % (__file__.rsplit("/", 1)[-1], os.getpid())
@@ -135,6 +137,8 @@ if not sr:
   sys.exit(1)
 
 BASEURL = "%s/%s/%s/" % (BASEURL, DATA_LOCATION, ERROR_FOLDER)
+# TODO: Remove this!!!!
+BASEURL = 'http://localhost:8030/data.json'
 
 # This method is just to test the sound infrastructure.
 # It will try to play a test message, send a test email and then exit.
@@ -179,7 +183,7 @@ def run_daemon():
       # counter.
       activeURLErrors = 0
 
-      state = cjson.decode(state)
+      state = json.loads(state)
 
       ## Detect No run state
       if noRun == False and len(state["contents"]) <= 1:
@@ -202,10 +206,24 @@ def run_daemon():
           name = histo['obj']
         else:
           continue
+       
+        # Get the disasbled alarms from the alarm manager:
+        disabledAlarms = []
+        try:
+	  datareq = urllib2.Request(ALARM_MANAGER_URL)
+          result = urllib2.build_opener(urllib2.ProxyHandler({})).open(datareq)
+          disabledAlarms = json.loads(result.read())
+        except:
+          # If we're unable to get disabled alarms, assume that they are enabled
+          pass
 
+        histoFullPath = '%s/%s' % (histo['dir'], histo['obj'])
         if histo['properties']['report']['alarm'] == 1:
-          knownNewAlarms.add(name)
-          logme("Info from the DQM GUI: %s" % str(histo))
+          if histoFullPath in disabledAlarms:
+            logme("Histo caused an alarm but it was disabled in the alarm manager: %s" % histoFullPath)
+          else:
+            knownNewAlarms.add(name)
+            logme("Info from the DQM GUI: %s" % str(histo))
 
       # should alarm be triggered
       alarmsNew = knownNewAlarms.difference(knownAlarms)

--- a/bin/visDQMSoundAlarmDaemon
+++ b/bin/visDQMSoundAlarmDaemon
@@ -41,9 +41,9 @@ from subprocess import Popen, PIPE
 
 # There is an extension to this tool called visDQMSoundAlarmManager.
 # It's a small web app which displays all plots located in ERROR_FOLDER
-# and provides an abillity to disable alarms for chosen plots. 
+# and provides an ability to disable alarms for chosen plots. 
 # This tool queries the API of the visDQMSoundAlarmManager for the list 
-# of disabled plots befre sending the alarms.
+# of disabled plots before sending the alarms.
 
 sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
 

--- a/bin/visDQMSoundAlarmManager
+++ b/bin/visDQMSoundAlarmManager
@@ -1,0 +1,220 @@
+#!/usr/bin/env python
+
+import sys
+import json
+import urllib2
+import SocketServer
+import SimpleHTTPServer
+from urllib import quote
+
+# Configurable parameters
+GUI_URL = 'http://localhost:8070/dqm/online-dev/'
+PORT = 8031
+
+if len(sys.argv) > 1:
+    GUI_URL = sys.argv[1]
+
+if len(sys.argv) > 2:
+    PORT = int(sys.argv[2])
+
+# Constants
+ERRORS_FOLDER = 'data/json/live/1/Global/Online/ALL/00 Shift/Errors'
+STATUSES = { 30: 'OTHER', 50: 'DISABLED', 60: 'INVALID', 70: 'INSUF_STAT', 90: 'DID_NOT_RUN',
+    100: 'STATUS_OK', 200: 'WARNING', 300: 'ERROR'
+}
+
+# Dict with keys of disabled ME names
+DISABLED_MES = {}
+
+def start():
+    SocketServer.TCPServer.allow_reuse_address = True
+    server = SocketServer.TCPServer(('0.0.0.0', PORT), CustomRequestHandler)
+    try:
+        server.serve_forever()
+    except:
+        pass
+    server.shutdown()
+
+class CustomRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
+    def do_GET(self):
+
+        # Return the main table
+        if self.path == '/':
+            state = self.get_gui_data()
+            content = ''
+
+            for index, item in enumerate(state['contents']):
+                if 'obj' in item:
+                    me = '%s/%s' % (item['dir'], item['obj'])
+                    content += '<tr>'
+                    content += '    <td>%s</td>' % me
+                    content += '    <td>%s</td>' % ', '.join(str(x['name']) for x in item['qresults'])
+                    content += '    <td>%s</td>' % ', '.join(str(x['algorithm']) for x in item['qresults'])
+                    content += '    <td>%s</td>' % ', '.join(str(x['message']) for x in item['qresults'])
+                    content += '    <td>%s</td>' % ', '.join(str(STATUSES.get(x['status'], x['status'])) for x in item['qresults'])
+                    content += '    <td>%s</td>' % ', '.join(str(x['result']) for x in item['qresults'])
+
+                    if me in DISABLED_MES:
+                        content += '    <td class="danger">No</td>'
+                        content += '    <td><button onclick="enable(\'%s\')">Enable</button></td>' % me
+                    else:
+                        content += '    <td class="success">Yes</td>'
+                        content += '    <td><button onclick="disable(\'%s\')">Disable</button></td>' % me
+
+                    content += '</tr>'
+                    
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(TEMPLATE.replace('$CONTENT$', content))
+        
+        # Return all enabled MEs
+        elif self.path == '/disabled':
+            result = []
+            for me in DISABLED_MES:
+                if DISABLED_MES[me]:
+                    result.append(me)
+            
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(json.dumps(result))
+        
+        else:
+            self.send_response(404)
+            self.end_headers()
+            self.wfile.write('<h1>404 Not Found</h1>')
+
+    def do_POST(self):
+        # Enable given ME
+        if self.path.startswith('/enable?me='):
+            me = self.path.split('/enable?me=', 1)[1]
+            DISABLED_MES.pop(me, None)
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(me)
+
+        # Disable given ME
+        elif self.path.startswith('/disable?me='):
+            me = self.path.split('/disable?me=', 1)[1]
+            DISABLED_MES[me] = True
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(me)
+        
+        else:
+            self.send_response(404)
+            self.end_headers()
+            self.wfile.write('<h1>404 Not Found</h1>')
+
+    def do_HEAD(self):
+        self.send_response(501)
+        self.end_headers()
+        self.wfile.write('<h1>501 Unsupported method</h1>')
+
+
+    def get_gui_data(self):
+        url = '%s%s' % (GUI_URL, quote(ERRORS_FOLDER))
+
+        try:
+            datareq = urllib2.Request(url)
+            result = urllib2.build_opener(urllib2.ProxyHandler({})).open(datareq)
+            state = result.read()
+        except:
+            return json.loads('{"contents": [{ "streamerinfo": "" }]}')
+
+        state = json.loads(state)
+
+        return state
+
+
+TEMPLATE = '''
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta charset="utf-8">
+	<title>DQM Sound Alarm Manager</title>
+	<style>
+		body {
+			font-family: arial, sans-serif;
+		}
+
+		h4, h3, h2, p {
+			padding-left: 6px;
+		}
+
+		table {
+			border-collapse: collapse;
+		}
+
+		td,
+		th {
+			text-align: left;
+			padding: 6px;
+		}
+
+		tr:nth-child(even) {
+			background-color: #f1f1f1;
+		}
+        
+        .danger {
+            color: #ff4242;
+        }
+
+        .success {
+            color: #00b30f;
+        }
+	</style>
+</head>
+
+<body>
+	<h3>Enable/disable DQM sound alarms at P5</h3>
+
+    <p>You can use this tool to enable/disable P5 sound alarms for certain DQM plot in the Errors folder of the DQM GUI. 
+    If the alarm for a plot is <i>enabled</i>, it <i>will play a sound alarm</i> in the control room.</p>
+
+    <p>All alarms will switch to enabled state after the restart of the DQM GUI.</p>
+
+    </br>
+
+	<table>
+		<tr>
+			<th>Monitor element</th>
+			<th>QResult name</th>
+			<th>QResult algorithm</th>
+			<th>QResult Message</th>
+            <th>QResult Status</th>
+            <th>QResult Result</th>
+            <th>Enabled</th>
+            <th>Action</th>
+		</tr>
+        $CONTENT$
+	</table>
+
+    <script>
+    function disable(me) {
+        fetch('/disable?me=' + me, {
+            method: 'post',
+        }).then(function(response) {
+            console.log(response)
+            location.reload()
+        })
+    }
+
+    function enable(me) {
+        fetch('/enable?me=' + me, {
+            method: 'post',
+        }).then(function(response) {
+            console.log(response)
+            location.reload()
+        })
+    }
+    </script>
+
+</body>
+
+</html>
+'''
+
+
+if __name__ == '__main__':
+    start()


### PR DESCRIPTION
Added a small web service for managing DQM sound alarms at CMS control room. Web service is accessible as a separate service from the DQM GUI. 

Before playing an alarm, `visDQMSoundAlarmDaemon` will retrieve the names of plots that have alarm disabled. The alarm will be played only if it is enabled. 

Names of disabled plots are stored in memory, therefore the settings get reset after every restart of the `visDQMSoundAlarmManager`. 

In case of any uncertainty/malfunction, alarms are considered to be enabled.